### PR TITLE
Disable spinner during clusterware installation

### DIFF
--- a/cobbler/snippets/clusterware.el6
+++ b/cobbler/snippets/clusterware.el6
@@ -5,6 +5,7 @@ if ! [ -z $clusterware ]; then
     dest="http://git.io/clusterware-installer"
   fi
   cat << EOF > /var/lib/symphony/firstrun/scripts/clusterware.bash
+  export alces_DISABLE_SPINNER=true
   curl -sL $dest | alces_OS=el6 /bin/bash &>/var/log/symphony/clusterwareinstall.log
   cat << EOD > /opt/clusterware/etc/config.yml
 ---

--- a/cobbler/snippets/clusterware.el7
+++ b/cobbler/snippets/clusterware.el7
@@ -5,6 +5,7 @@ if ! [ -z $clusterware ]; then
     dest="http://git.io/clusterware-installer"
   fi
   cat << EOF > /var/lib/symphony/firstrun/scripts/clusterware.bash
+  export alces_DISABLE_SPINNER=true
   curl -sL $dest | alces_OS=el7 /bin/bash &>/var/log/symphony/clusterwareinstall.log
 cat << EOD > /opt/clusterware/etc/config.yml
 ---


### PR DESCRIPTION
This patch adds a setting of the `alces_DISABLE_SPINNER` environment variable to prevent the `\|/-/|-`spam in the logs.
